### PR TITLE
Fix overall responsiveness

### DIFF
--- a/packages/frontend/components/BlockiesAvatar.tsx
+++ b/packages/frontend/components/BlockiesAvatar.tsx
@@ -21,6 +21,7 @@ export const BlockiesAvatar = ({
       src={avatarDataUrl}
       fallbackSrc="https://via.placeholder.com/150"
       alt={address}
+      borderRadius="full"
       sx={{ imageRendering: 'pixelated' }}
       {...rest}
     />

--- a/packages/frontend/components/BlockiesAvatar.tsx
+++ b/packages/frontend/components/BlockiesAvatar.tsx
@@ -1,35 +1,28 @@
-import { Box, Image } from '@chakra-ui/react'
 import blockies from 'blockies-ts'
-import { FC, useEffect, useState } from 'react'
+import { Image } from '@chakra-ui/react'
+import type { ImageProps } from '@chakra-ui/react'
+import { useMemo } from 'react'
 
-export interface BlockiesAvatarProps {
-  address: string | undefined
-  ml?: string
-  borderRadius?: string
-  width?: string | number
-  height?: string | number
-  cursor?: string
+export interface BlockiesAvatarProps extends ImageProps {
+  address?: string
 }
-export const BlockiesAvatar: FC<BlockiesAvatarProps> = ({
-  address,
-  ...props
-}) => {
-  const [avatarUri, setAvatarUri] = useState('')
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    const blockieImageSrc = blockies.create({ seed: (address || '').toLowerCase() }).toDataURL()
-    setAvatarUri(blockieImageSrc)
-  }, [address])
+
+export const BlockiesAvatar = ({
+  address = '',
+  ...rest
+}: BlockiesAvatarProps): JSX.Element => {
+  const avatarDataUrl = useMemo(
+    () => blockies.create({ seed: address.toLowerCase() }).toDataURL(),
+    [address]
+  )
 
   return (
-    <Box>
-      <Image
-        src={avatarUri}
-        fallbackSrc="https://via.placeholder.com/150"
-        alt={address || ''}
-        style={{ imageRendering: 'pixelated' }}
-        {...props}
-      />
-    </Box>
+    <Image
+      src={avatarDataUrl}
+      fallbackSrc="https://via.placeholder.com/150"
+      alt={address}
+      sx={{ imageRendering: 'pixelated' }}
+      {...rest}
+    />
   )
 }

--- a/packages/frontend/components/ChainSwitchMenu.tsx
+++ b/packages/frontend/components/ChainSwitchMenu.tsx
@@ -33,10 +33,10 @@ export const ChainSwitchMenu: FC<ChainSwitchMenuProps> = ({...props}) => {
 
   return <>
     <Menu >
-      <Tooltip label={activeChain.name} aria-label={activeChain.name}>
+      <Tooltip label={activeChain.name} aria-label={activeChain.name} gutter={10}>
         <MenuButton as={Button} rightIcon={<BsChevronDown />} bgColor={activeChain?.unsupported ? 'red.100' : ''} {...props}>
           {activeChain?.unsupported
-            ? <Text>Unsupported Chain</Text>
+            ? <Text>Invalid Chain</Text>
             : <Image src={`/icons/networks/${activeChain.id}.svg`} alt={activeChain.name} boxSize='1.5rem' mr="1" />}
         </MenuButton>
       </Tooltip>

--- a/packages/frontend/components/ConnectWallet.tsx
+++ b/packages/frontend/components/ConnectWallet.tsx
@@ -1,7 +1,11 @@
 import {
   Button,
-  Flex, Menu,
-  MenuButton, MenuItem, MenuList, Text
+  Flex,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  Text,
 } from '@chakra-ui/react'
 import { useEnsDomain } from '@lib/useEnsDomain'
 import { useIsSSR } from '@lib/useIsSSR'
@@ -12,37 +16,40 @@ import { BlockiesAvatar } from './BlockiesAvatar'
 import { ChainSwitchMenu } from './ChainSwitchMenu'
 import ConnectWalletButton from './ConnectWalletButton'
 
-
 function truncateHash(hash: string, length = 38): string {
   return hash.replace(hash.substring(6, length), '...')
 }
 
 function ConnectWallet(): JSX.Element {
-  const { data: accountData} = useAccount()
+  const { data: accountData } = useAccount()
   const { disconnect } = useDisconnect()
   const isSSR = useIsSSR()
-  const {ensDomain} = useEnsDomain({address: accountData?.address})
+  const { ensDomain } = useEnsDomain({ address: accountData?.address })
 
-  if(isSSR || !accountData?.address) return <ConnectWalletButton />
+  if (isSSR || !accountData?.address) return <ConnectWalletButton />
 
-  return (<>
-    <Flex
-      order={[-1, null, null, 2]}
-      alignItems={'center'}
-      justifyContent={['flex-start', null, null, 'flex-end']}
-    >
+  return (
+    <Flex alignItems={'center'}>
       {/* Avatar */}
-      <Link href={`/users/${(accountData?.address || '').toLowerCase()}`} passHref>
+      <Link
+        href={`/users/${(accountData?.address || '').toLowerCase()}`}
+        passHref
+      >
         <div>
-          <BlockiesAvatar address={accountData.address} ml="4" borderRadius={'full'} cursor='pointer'/>
+          <BlockiesAvatar
+            address={accountData.address}
+            ml="4"
+            borderRadius={'full'}
+            cursor="pointer"
+          />
         </div>
       </Link>
 
       {/* Chain Switch Menu */}
-      <ChainSwitchMenu ml='4' />
+      <ChainSwitchMenu ml="4" />
 
       {/* Address / ENS-Name */}
-      <Menu placement="bottom-end" >
+      <Menu placement="bottom-end">
         <MenuButton as={Button} ml="4">
           <Flex direction="column">
             <Text>{ensDomain || truncateHash(accountData.address || '')}</Text>
@@ -53,7 +60,7 @@ function ConnectWallet(): JSX.Element {
         </MenuList>
       </Menu>
     </Flex>
-  </>)
+  )
 }
 
 export default ConnectWallet

--- a/packages/frontend/components/ConnectWalletButton.tsx
+++ b/packages/frontend/components/ConnectWalletButton.tsx
@@ -1,13 +1,18 @@
 import {
-  Button, Modal, ModalBody, ModalContent, ModalHeader, ModalOverlay, useDisclosure, VStack
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  useDisclosure,
+  VStack,
 } from '@chakra-ui/react'
+import type { ButtonProps } from '@chakra-ui/react'
 import React from 'react'
 import { useConnect } from 'wagmi'
 
-export type ConnectWalletButtonProps = {
-  title?: string
-}
-function ConnectWalletButton({title}: ConnectWalletButtonProps): JSX.Element {
+function ConnectWalletButton({ children, ...rest }: ButtonProps): JSX.Element {
   const { connectors, connect } = useConnect()
   const { isOpen, onOpen, onClose } = useDisclosure()
 
@@ -18,7 +23,7 @@ function ConnectWalletButton({title}: ConnectWalletButtonProps): JSX.Element {
         <ModalContent>
           <ModalHeader>Connect your wallet of choice</ModalHeader>
           <ModalBody>
-            <VStack align={'stretch'} pb='4'>
+            <VStack align={'stretch'} pb="4">
               {connectors?.map((connector) => (
                 <Button key={connector.id} onClick={() => connect(connector)}>
                   {connector.name}
@@ -29,12 +34,8 @@ function ConnectWalletButton({title}: ConnectWalletButtonProps): JSX.Element {
         </ModalContent>
       </Modal>
 
-      <Button
-        w="220px"
-        variant="solid"
-        onClick={onOpen}
-      >
-        {title || 'Connect Wallet'}
+      <Button w="200px" variant="solid" onClick={onOpen} {...rest}>
+        {children || 'Connect Wallet'}
       </Button>
     </>
   )

--- a/packages/frontend/components/ConnectWalletButton.tsx
+++ b/packages/frontend/components/ConnectWalletButton.tsx
@@ -1,3 +1,4 @@
+import type { ButtonProps } from '@chakra-ui/react'
 import {
   Button,
   Modal,
@@ -6,9 +7,8 @@ import {
   ModalHeader,
   ModalOverlay,
   useDisclosure,
-  VStack,
+  VStack
 } from '@chakra-ui/react'
-import type { ButtonProps } from '@chakra-ui/react'
 import React from 'react'
 import { useConnect } from 'wagmi'
 

--- a/packages/frontend/components/SponsorsCard.tsx
+++ b/packages/frontend/components/SponsorsCard.tsx
@@ -1,4 +1,4 @@
-import { Flex, Heading, WrapItem, Wrap } from '@chakra-ui/react'
+import { Flex, Heading, Tooltip, Wrap, WrapItem } from '@chakra-ui/react'
 import { BlockiesAvatar } from './BlockiesAvatar'
 
 interface BlockiesAvatarProps {
@@ -13,9 +13,11 @@ function SponsorsCard({ sponsors }: BlockiesAvatarProps) {
       <Heading size="lg">Sponsors</Heading>
       <Wrap display="flex">
         {sponsors.map((sponsor) => (
-          <WrapItem key={sponsor}>
-            <BlockiesAvatar address={sponsor} borderRadius="full" width={12} />
-          </WrapItem>
+          <Tooltip key={sponsor} label={sponsor} fontSize={12} whiteSpace='nowrap'>
+            <WrapItem >
+              <BlockiesAvatar address={sponsor} borderRadius="full" width={12} />
+            </WrapItem>
+          </Tooltip>
         ))}
       </Wrap>
     </Flex>

--- a/packages/frontend/components/creator/CreatorCard.tsx
+++ b/packages/frontend/components/creator/CreatorCard.tsx
@@ -38,7 +38,6 @@ export const CreatorCard: FC<CreatorCardProps> = ({
       <CreatorCardDetails creator={creator} />
 
       <Divider />
-
       <VStack w="full">
         {accountData
           ? activeChain?.unsupported

--- a/packages/frontend/components/creator/CreatorCardDetails.tsx
+++ b/packages/frontend/components/creator/CreatorCardDetails.tsx
@@ -8,21 +8,24 @@ import { FC } from 'react'
 export interface CreatorCardDetailsProps {
   creator: Creator
 }
-export const CreatorCardDetails: FC<CreatorCardDetailsProps> = ({creator}) => {
-  const {ensDomain} = useEnsDomain({address: creator.address})
+export const CreatorCardDetails: FC<CreatorCardDetailsProps> = ({
+  creator,
+}) => {
+  const { ensDomain } = useEnsDomain({ address: creator.address })
 
-  return <>
-    <BlockiesAvatar
-      address={creator?.address}
-      borderRadius="full"
-      width="200px"
-      height="200px"
-    />
-    <VStack w="full">
-      <Heading textAlign={'center'}>
-        {creator.displayName || ensDomain || truncateHash(creator.address)}
-      </Heading>
-      <Text textAlign={'center'}>{creator?.description}</Text>
-    </VStack>
-  </>
+  return (
+    <>
+      <BlockiesAvatar
+        address={creator?.address}
+        borderRadius="full"
+        width={{ base: '120px', md: '200px' }}
+      />
+      <VStack w="full">
+        <Heading textAlign={'center'}>
+          {creator.displayName || ensDomain || truncateHash(creator.address)}
+        </Heading>
+        <Text textAlign={'center'}>{creator?.description}</Text>
+      </VStack>
+    </>
+  )
 }

--- a/packages/frontend/components/creator/CreatorCardNumbers.tsx
+++ b/packages/frontend/components/creator/CreatorCardNumbers.tsx
@@ -4,28 +4,41 @@ import { FC } from 'react'
 import { Chain } from 'wagmi'
 
 export interface CreatorCardNumbersProps {
-  creator: Creator,
-  totalAmountStaked: number,
-  totalAmountStakedIsLoading: boolean,
-  contractChain: Chain,
+  creator: Creator
+  totalAmountStaked: number
+  totalAmountStakedIsLoading: boolean
+  contractChain: Chain
 }
-export const CreatorCardNumbers: FC<CreatorCardNumbersProps> = ({creator, totalAmountStaked, totalAmountStakedIsLoading: isLoading, contractChain}) => {
-  return <>
-    <HStack spacing={8} mx={8}>
-      <Flex direction="column" align="center">
-        <Heading>{creator.supportersCount}</Heading>
-        <Text>Supporters</Text>
-      </Flex>
-      <Flex direction="column" align="center">
-        {isLoading
-          ? <Heading><Spinner /></Heading>
-          : <Heading>{totalAmountStaked || '0.0'}</Heading>}
-        <Text>Staked {contractChain?.nativeCurrency?.symbol || 'ETH'}</Text>
-      </Flex>
-      <Flex direction="column" align="center">
-        <Heading>{creator.postsCount}</Heading>
-        <Text>Posts</Text>
-      </Flex>
-    </HStack>
-  </>
+export const CreatorCardNumbers: FC<CreatorCardNumbersProps> = ({
+  creator,
+  totalAmountStaked,
+  totalAmountStakedIsLoading: isLoading,
+  contractChain,
+}) => {
+  return (
+    <>
+      <HStack spacing={8} mx={8} wrap="wrap" placeContent="center">
+        <Flex direction="column" align="center">
+          <Heading>{creator.supportersCount}</Heading>
+          <Text textAlign="center">Supporters</Text>
+        </Flex>
+        <Flex direction="column" align="center">
+          {isLoading ? (
+            <Heading>
+              <Spinner />
+            </Heading>
+          ) : (
+            <Heading>{totalAmountStaked || '0.0'}</Heading>
+          )}
+          <Text textAlign="center">
+            Staked {contractChain?.nativeCurrency?.symbol || 'ETH'}
+          </Text>
+        </Flex>
+        <Flex direction="column" align="center">
+          <Heading>{creator.postsCount}</Heading>
+          <Text textAlign="center">Posts</Text>
+        </Flex>
+      </HStack>
+    </>
+  )
 }

--- a/packages/frontend/components/creator/CreatorCardNumbers.tsx
+++ b/packages/frontend/components/creator/CreatorCardNumbers.tsx
@@ -1,4 +1,4 @@
-import { Flex, Heading, HStack, Spinner, Text } from '@chakra-ui/react'
+import { Flex, Heading, HStack, Spinner, Text, useMediaQuery } from '@chakra-ui/react'
 import { Creator } from '@entities/Creator.entity'
 import { FC } from 'react'
 import { Chain } from 'wagmi'
@@ -15,6 +15,8 @@ export const CreatorCardNumbers: FC<CreatorCardNumbersProps> = ({
   totalAmountStakedIsLoading: isLoading,
   contractChain,
 }) => {
+  const [isMobile] = useMediaQuery('(max-width: 500px)') 
+
   return (
     <>
       <HStack spacing={8} mx={8} wrap="wrap" placeContent="center">
@@ -31,7 +33,7 @@ export const CreatorCardNumbers: FC<CreatorCardNumbersProps> = ({
             <Heading>{totalAmountStaked || '0.0'}</Heading>
           )}
           <Text textAlign="center">
-            Staked {contractChain?.nativeCurrency?.symbol || 'ETH'}
+            {!isMobile && 'Staked '} {contractChain?.nativeCurrency?.symbol || 'ETH'}
           </Text>
         </Flex>
         <Flex direction="column" align="center">

--- a/packages/frontend/components/creator/CreatorsList.tsx
+++ b/packages/frontend/components/creator/CreatorsList.tsx
@@ -1,4 +1,17 @@
-import { Button, Flex, Heading, HStack, Input, InputGroup, InputLeftElement, Link, Spacer, Spinner, Text } from '@chakra-ui/react'
+import {
+  Button,
+  Flex,
+  Grid,
+  Heading,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  Link,
+  Spinner,
+  Text,
+  VStack,
+} from '@chakra-ui/react'
+import type { StackProps } from '@chakra-ui/react'
 import { Creator } from '@entities/Creator.entity'
 import { useTotalAmountStaked } from '@lib/creatorReadHooks'
 import { truncateHash } from '@lib/truncateHash'
@@ -8,100 +21,177 @@ import { FC, useEffect, useState } from 'react'
 import { BsSearch } from 'react-icons/bs'
 import { BlockiesAvatar } from '../BlockiesAvatar'
 
+interface StatProps extends StackProps {
+  isLoading?: boolean
+  label: string
+  value: number | string
+}
+
+const Stat = ({
+  isLoading = false,
+  label,
+  value,
+  ...rest
+}: StatProps): JSX.Element => {
+  return (
+    <VStack spacing="0" {...rest}>
+      <Text fontSize={{ base: '2xl', lg: '3xl' }} fontWeight="bold">
+        {isLoading ? <Spinner /> : value}
+      </Text>
+      <Text
+        fontSize={{ base: 'sm', lg: 'md' }}
+        textAlign="center"
+        whiteSpace="nowrap"
+      >
+        {label}
+      </Text>
+    </VStack>
+  )
+}
+
 export interface CreatorsListItemProps {
   creator: Creator
 }
-export const CreatorsListItem: FC<CreatorsListItemProps> = ({creator}) => {
-  const isSSR = useIsSSR()
-  const { totalAmountStaked, isLoading, contractChain } = useTotalAmountStaked({ beneficiary: creator.address })
 
-  return <>
+export const CreatorsListItem = ({
+  creator,
+}: CreatorsListItemProps): JSX.Element => {
+  const isSSR = useIsSSR()
+  const { totalAmountStaked, isLoading, contractChain } = useTotalAmountStaked({
+    beneficiary: creator.address,
+  })
+
+  return (
     <NextLink href={`/users/${creator.address}`} passHref>
       <Link _hover={{ textDecoration: 'none' }}>
-        <Flex direction="column" border="1px" p={8} borderRadius="md">
-          <Flex align="center">
-            <BlockiesAvatar address={creator.address} borderRadius="full" width="100px" height="100px"/>
-            <Flex direction="column" align="left" mx={8}>
-              <Heading>
-                {creator.displayName || truncateHash(creator.address)}
-              </Heading>
-              <Text>{creator.description}</Text>
-            </Flex>
-            <Spacer />
-            <HStack spacing="24px" mx={8}>
-              <Flex direction="column" align="center">
-                <Heading>{creator.supportersCount}</Heading>
-                <Text>Supporters</Text>
-              </Flex>
-              <Flex direction="column" align="center">
-                <Heading>{creator.postsCount}</Heading>
-                <Text>Posts</Text>
-              </Flex>
-              {!isSSR &&
-                <Flex direction="column" align="center">
-                  {isLoading
-                    ? <Heading><Spinner /></Heading>
-                    : <Heading>{totalAmountStaked || '0.0'}</Heading>}
-                  <Text>Staked {contractChain?.nativeCurrency?.symbol}</Text>
-                </Flex>}
-            </HStack>
+        <Grid
+          templateAreas={{
+            base: '"avatar" "name" "stats"',
+            sm: '"avatar name" "avatar stats"',
+            md: '"avatar name stats"',
+          }}
+          templateColumns={{
+            base: '1fr',
+            sm: 'auto auto',
+            md: 'auto auto 1fr',
+          }}
+          gap={{
+            base: '2',
+            sm: '5',
+            md: '8',
+          }}
+          placeItems="center"
+          placeContent="center"
+          p="8"
+          border="1px"
+          borderRadius="md"
+        >
+          <BlockiesAvatar
+            address={creator.address}
+            width={{ base: '80px', sm: '100px' }}
+            gridArea="avatar"
+            justifySelf="center"
+          />
+          <Flex direction="column" gridArea="name">
+            <Heading
+              textAlign={{ base: 'center', md: 'left' }}
+              fontSize={{ base: '2xl', sm: '3xl' }}
+            >
+              {creator.displayName || truncateHash(creator.address)}
+            </Heading>
+            <Text textAlign={{ base: 'center', md: 'left' }}>
+              {creator.description}
+            </Text>
           </Flex>
-        </Flex>
+          <Flex
+            gap="2"
+            wrap="wrap"
+            justifyContent="center"
+            gridArea="stats"
+            justifySelf={{ base: 'center', md: 'end' }}
+          >
+            {creator.supportersCount && (
+              <Stat label="Supporters" value={creator.supportersCount} />
+            )}
+            {creator.postsCount && (
+              <Stat label="Posts" value={creator.postsCount} />
+            )}
+            {!isSSR && (
+              <Stat
+                isLoading={isLoading}
+                label={`Stakes ${contractChain?.nativeCurrency?.symbol}`}
+                value={totalAmountStaked || '0.0'}
+              />
+            )}
+          </Flex>
+        </Grid>
       </Link>
     </NextLink>
-  </>
+  )
 }
-
 
 export interface CreatorsListProps {
   creators: Creator[]
 }
-export const CreatorsList: FC<CreatorsListProps> = ({creators}) => {
+
+export const CreatorsList: FC<CreatorsListProps> = ({ creators }) => {
   const [shownCreators, setShownCreators] = useState<Creator[]>([])
   const [searchString, setSearchString] = useState<string>('')
   const [maxShownAmount, setMaxShownAmount] = useState<number>(5)
 
   const updateFilteredCreators = () => {
-    const newShownCreators = creators.filter((creator) => !searchString
-        || creator.displayName?.match(new RegExp(searchString, 'i'))
-        || creator.address?.match(new RegExp(searchString, 'i'))
-        || creator.ensName?.match(new RegExp(searchString, 'i')))
+    const newShownCreators = creators.filter(
+      (creator) =>
+        !searchString ||
+        creator.displayName?.match(new RegExp(searchString, 'i')) ||
+        creator.address?.match(new RegExp(searchString, 'i')) ||
+        creator.ensName?.match(new RegExp(searchString, 'i'))
+    )
     setShownCreators(newShownCreators)
   }
   useEffect(() => {
     updateFilteredCreators()
   }, [searchString])
 
-  return <>
-    <Flex direction="column">
-      <Heading mt={24} mb={12} textAlign="center">
-            Explore and sponsor our creators
-      </Heading>
+  return (
+    <>
+      <Flex direction="column">
+        <Heading mt={24} mb={12} textAlign="center">
+          Explore and sponsor our creators
+        </Heading>
 
-      {/* Search Field */}
-      <InputGroup size="lg">
-        <InputLeftElement
-          pointerEvents="none"
-          children={<BsSearch size={20} />}
-        />
-        <Input placeholder="Find creator" onChange={(event) => {
-          setSearchString(event?.target?.value || '')
-        }} />
-      </InputGroup>
+        {/* Search Field */}
+        <InputGroup size="lg">
+          <InputLeftElement
+            pointerEvents="none"
+            children={<BsSearch size={20} />}
+          />
+          <Input
+            placeholder="Find creator"
+            onChange={(event) => {
+              setSearchString(event?.target?.value || '')
+            }}
+          />
+        </InputGroup>
 
-      {/* Creators List */}
-      <Flex direction="column" gap={8} py={8}>
-        {(shownCreators || []).slice(0, maxShownAmount).map((creator) => (
-          <CreatorsListItem key={creator._id} creator={creator} />
-        ))}
+        {/* Creators List */}
+        <Flex direction="column" gap={8} py={8}>
+          {(shownCreators || []).slice(0, maxShownAmount).map((creator) => (
+            <CreatorsListItem key={creator._id} creator={creator} />
+          ))}
+        </Flex>
+
+        {/* Show more Button */}
+        {!searchString && maxShownAmount <= creators.length && (
+          <Button
+            onClick={() => {
+              setMaxShownAmount(maxShownAmount + 5)
+            }}
+          >
+            Show more
+          </Button>
+        )}
       </Flex>
-
-      {/* Show more Button */}
-      {(!searchString && maxShownAmount <= creators.length) &&
-        <Button onClick={() => { setMaxShownAmount(maxShownAmount + 5) }}>
-          Show more
-        </Button>}
-    </Flex>
-
-  </>
+    </>
+  )
 }

--- a/packages/frontend/components/creator/CreatorsList.tsx
+++ b/packages/frontend/components/creator/CreatorsList.tsx
@@ -1,5 +1,5 @@
 import {
-  Button,
+  Box, Button,
   Flex,
   Grid,
   Heading,
@@ -7,11 +7,9 @@ import {
   InputGroup,
   InputLeftElement,
   Link,
-  Spinner,
-  Text,
-  VStack,
+  Spinner, StackProps, Text,
+  VStack
 } from '@chakra-ui/react'
-import type { StackProps } from '@chakra-ui/react'
 import { Creator } from '@entities/Creator.entity'
 import { useTotalAmountStaked } from '@lib/creatorReadHooks'
 import { truncateHash } from '@lib/truncateHash'
@@ -35,9 +33,10 @@ const Stat = ({
 }: StatProps): JSX.Element => {
   return (
     <VStack spacing="0" {...rest}>
-      <Text fontSize={{ base: '2xl', lg: '3xl' }} fontWeight="bold">
-        {isLoading ? <Spinner /> : value}
-      </Text>
+      {isLoading
+        ? <Box flexGrow={1} display='flex' justifyContent={'center'} alignItems={'center'}><Spinner /></Box>
+        : <Text fontSize={{ base: '2xl', lg: '3xl' }} fontWeight="bold">{value}</Text>
+      }
       <Text
         fontSize={{ base: 'sm', lg: 'md' }}
         textAlign="center"

--- a/packages/frontend/components/layout/Footer.tsx
+++ b/packages/frontend/components/layout/Footer.tsx
@@ -1,0 +1,50 @@
+import { Box, Container, Flex, Grid, GridItem, Icon, Link, Text } from '@chakra-ui/react'
+import NextLink from 'next/link'
+import * as React from 'react'
+import { BsGithub, BsTwitter } from 'react-icons/bs'
+
+
+function Footer(): JSX.Element {
+  return (
+    <Box borderTop="1px" mt="10">
+      <Container maxW="5xl" py={4}>
+        <Grid
+          as="footer"
+          templateAreas={{
+            base: '"love" "email" "social"',
+            md: '"social love email"',
+          }}
+          templateColumns={{ base: '1fr', md: '180px 1fr 180px' }}
+          placeItems="center"
+          gap="4"
+        >
+          <Flex gap="4" gridArea="social" justifySelf={{ md: 'start' }}>
+            <NextLink href="https://twitter.com/yieldgate" passHref>
+              <Link>
+                <Icon as={BsTwitter} boxSize="8" color="gray.700" />
+              </Link>
+            </NextLink>
+            <NextLink href="https://github.com/yieldgate" passHref>
+              <Link>
+                <Icon as={BsGithub} boxSize="8" color="gray.700" />
+              </Link>
+            </NextLink>
+          </Flex>
+          <GridItem textAlign="center" gridArea="love">
+      Built with ❤️ at ETHGlobal{' '}
+            <Text as="span" whiteSpace="nowrap">
+        Amsterdam 🇳🇱
+            </Text>
+          </GridItem>
+          <GridItem gridArea="email" justifySelf={{ md: 'end' }}>
+            <NextLink href="mailto:hi@yieldgate.xyz" passHref>
+              <Link>hi@yieldgate.xyz</Link>
+            </NextLink>
+          </GridItem>
+        </Grid>
+      </Container>
+    </Box>
+  )
+}
+
+export default Footer

--- a/packages/frontend/components/layout/Layout.tsx
+++ b/packages/frontend/components/layout/Layout.tsx
@@ -1,7 +1,6 @@
-import { Box, Flex, Grid, GridItem, Icon, Link, Text } from '@chakra-ui/react'
-import NextLink from 'next/link'
+import { Box, Flex } from '@chakra-ui/react'
 import React from 'react'
-import { BsGithub, BsTwitter } from 'react-icons/bs'
+import Footer from './Footer'
 import Navbar from './Navbar'
 
 interface LayoutProps {
@@ -17,43 +16,7 @@ const Layout = ({ children }: LayoutProps): JSX.Element => {
       <Box as="main" flexGrow={1}>
         {children}
       </Box>
-      <Grid
-        as="footer"
-        templateAreas={{
-          base: '"love" "email" "social"',
-          md: '"social love email"',
-        }}
-        templateColumns={{ base: '1fr', md: '180px 1fr 180px' }}
-        placeItems="center"
-        gap="4"
-        borderTop="1px"
-        mt="12"
-        p="5"
-      >
-        <Flex gap="4" gridArea="social" justifySelf={{ md: 'start' }}>
-          <NextLink href="https://twitter.com/yieldgate" passHref>
-            <Link>
-              <Icon as={BsTwitter} boxSize="8" color="gray.700" />
-            </Link>
-          </NextLink>
-          <NextLink href="https://github.com/yieldgate" passHref>
-            <Link>
-              <Icon as={BsGithub} boxSize="8" color="gray.700" />
-            </Link>
-          </NextLink>
-        </Flex>
-        <GridItem textAlign="center" gridArea="love">
-          Built with ❤️ at ETHGlobal{' '}
-          <Text as="span" whiteSpace="nowrap">
-            Amsterdam 🇳🇱
-          </Text>
-        </GridItem>
-        <GridItem gridArea="email" justifySelf={{ md: 'end' }}>
-          <NextLink href="mailto:hi@yieldgate.xyz" passHref>
-            <Link>hi@yieldgate.xyz</Link>
-          </NextLink>
-        </GridItem>
-      </Grid>
+      <Footer />
     </Flex>
   )
 }

--- a/packages/frontend/components/layout/Layout.tsx
+++ b/packages/frontend/components/layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Grid, GridItem, Icon, Link } from '@chakra-ui/react'
+import { Box, Flex, Grid, GridItem, Icon, Link, Text } from '@chakra-ui/react'
 import NextLink from 'next/link'
 import React from 'react'
 import { BsGithub, BsTwitter } from 'react-icons/bs'
@@ -10,19 +10,27 @@ interface LayoutProps {
 
 const Layout = ({ children }: LayoutProps): JSX.Element => {
   return (
-    <>
+    <Flex direction="column" minH="100vh">
       <header>
         <Navbar />
       </header>
-      <Box as="main">{children}</Box>
+      <Box as="main" flexGrow={1}>
+        {children}
+      </Box>
       <Grid
         as="footer"
+        templateAreas={{
+          base: '"love" "email" "social"',
+          md: '"social love email"',
+        }}
+        templateColumns={{ base: '1fr', md: '180px 1fr 180px' }}
+        placeItems="center"
+        gap="4"
         borderTop="1px"
-        p={5}
         mt="12"
-        templateColumns="300px 1fr 300px"
+        p="5"
       >
-        <Flex gap={5}>
+        <Flex gap="4" gridArea="social" justifySelf={{ md: 'start' }}>
           <NextLink href="https://twitter.com/yieldgate" passHref>
             <Link>
               <Icon as={BsTwitter} boxSize="8" color="gray.700" />
@@ -34,16 +42,19 @@ const Layout = ({ children }: LayoutProps): JSX.Element => {
             </Link>
           </NextLink>
         </Flex>
-        <GridItem placeSelf="center">
-          Built with ❤️ at ETHGlobal Amsterdam 🇳🇱
+        <GridItem textAlign="center" gridArea="love">
+          Built with ❤️ at ETHGlobal{' '}
+          <Text as="span" whiteSpace="nowrap">
+            Amsterdam 🇳🇱
+          </Text>
         </GridItem>
-        <GridItem justifySelf="end">
+        <GridItem gridArea="email" justifySelf={{ md: 'end' }}>
           <NextLink href="mailto:hi@yieldgate.xyz" passHref>
             <Link>hi@yieldgate.xyz</Link>
           </NextLink>
         </GridItem>
       </Grid>
-    </>
+    </Flex>
   )
 }
 

--- a/packages/frontend/pages/index.tsx
+++ b/packages/frontend/pages/index.tsx
@@ -141,18 +141,44 @@ export default function IndexPage({ creators }: IndexPageProps) {
           </Heading>
           <Grid
             templateColumns="1fr 1fr"
+            sx={{
+              '@media (max-width: 600px)': {
+                gridTemplateColumns: '1fr',
+              },
+            }}
             templateRows="100px 100px"
-            gap="20"
+            px="10"
+            gap="10"
             placeItems="center"
           >
-            <Image src="/images/aave.svg" h="60%" alt="AAVE" />
-            <Image src="/images/polygon.svg" h="70%" alt="Polygon" />
+            <Image
+              src="/images/aave.svg"
+              alt="AAVE"
+              w="90%"
+              maxH="14"
+              objectFit="contain"
+            />
+            <Image
+              src="/images/polygon.svg"
+              alt="Polygon"
+              w="90%"
+              maxH="14"
+              objectFit="contain"
+            />
             <Image
               src="/images/walletconnect.svg"
-              h="60%"
               alt="WalletConnect"
+              w="100%"
+              maxH="16"
+              objectFit="contain"
             />
-            <Image src="/images/coinbase.svg" h="50%" alt="Coinbase" />
+            <Image
+              src="/images/coinbase.svg"
+              alt="Coinbase"
+              w="90%"
+              maxH="14"
+              objectFit="contain"
+            />
           </Grid>
         </Flex>
       </Container>

--- a/packages/frontend/pages/index.tsx
+++ b/packages/frontend/pages/index.tsx
@@ -1,4 +1,12 @@
-import { Button, Container, Flex, Grid, Heading, Image, Text } from '@chakra-ui/react'
+import {
+  Button,
+  Container,
+  Flex,
+  Grid,
+  Heading,
+  Image,
+  Text,
+} from '@chakra-ui/react'
 import { CreatorsList } from '@components/creator/CreatorsList'
 import Layout from '@components/layout/Layout'
 import { Creator } from '@entities/Creator.entity'
@@ -24,7 +32,12 @@ export default function IndexPage({ creators }: IndexPageProps) {
       >
         <Container maxW="5xl" py={24}>
           <Flex direction="column" align="start" gap={3}>
-            <Image src="/images/logo-yieldgate-long.svg" h="70px" mb={2} alt="Yieldgate Cover Image" />
+            <Image
+              src="/images/logo-yieldgate-long.svg"
+              h="70px"
+              mb={2}
+              alt="Yieldgate Cover Image"
+            />
             <Text fontSize="3xl" fontWeight={700}>
               Earn yield from your supporters.
               <br />
@@ -51,21 +64,36 @@ export default function IndexPage({ creators }: IndexPageProps) {
             fontSize="2xl"
             textAlign="center"
           >
-            Yieldgate is a protocol that allows anyone to start earning and building products with programmable yield.
+            Yieldgate is a protocol that allows anyone to start earning and
+            building products with programmable yield.
           </Text>
         </Flex>
         <Flex direction="column">
           <Heading mt={24} mb={12} textAlign="center">
             How does it work?
           </Heading>
-          <Grid gridTemplateColumns="repeat(3, 1fr)" gap={10}>
+          <Grid
+            gap="5"
+            gridTemplateColumns="repeat(3, 1fr)"
+            sx={{
+              '@media (max-width: 600px)': {
+                gridTemplateColumns: '1fr',
+              },
+            }}
+          >
             <Flex
               direction="column"
               border="1px"
               borderRadius="md"
               overflow="hidden"
             >
-              <Image src="/images/step-1.png" h={52} alt="Step 1" />
+              <Image
+                src="/images/step-1.png"
+                alt="Step 1"
+                maxH="48"
+                objectFit="cover"
+                objectPosition="top"
+              />
               <Text p={5} fontSize="xl">
                 Sign in with your wallet
               </Text>
@@ -76,7 +104,13 @@ export default function IndexPage({ creators }: IndexPageProps) {
               borderRadius="md"
               overflow="hidden"
             >
-              <Image src="/images/step-2.png" h={52} alt="Step 2" />
+              <Image
+                src="/images/step-2.png"
+                alt="Step 2"
+                maxH="48"
+                objectFit="cover"
+                objectPosition="top"
+              />
               <Text p={5} fontSize="xl">
                 Edit your profile and make your first post
               </Text>
@@ -87,10 +121,15 @@ export default function IndexPage({ creators }: IndexPageProps) {
               borderRadius="md"
               overflow="hidden"
             >
-              <Image src="/images/step-3.png" h={52} alt="Step 3" />
+              <Image
+                src="/images/step-3.png"
+                alt="Step 3"
+                maxH="48"
+                objectFit="cover"
+                objectPosition="top"
+              />
               <Text p={5} fontSize="xl">
-                Share your Yieldgate profile to start receiving donations from
-                your supporters in yield!
+                Start receiving yield from your supporters!
               </Text>
             </Flex>
           </Grid>
@@ -108,7 +147,11 @@ export default function IndexPage({ creators }: IndexPageProps) {
           >
             <Image src="/images/aave.svg" h="60%" alt="AAVE" />
             <Image src="/images/polygon.svg" h="70%" alt="Polygon" />
-            <Image src="/images/walletconnect.svg" h="60%" alt="WalletConnect" />
+            <Image
+              src="/images/walletconnect.svg"
+              h="60%"
+              alt="WalletConnect"
+            />
             <Image src="/images/coinbase.svg" h="50%" alt="Coinbase" />
           </Grid>
         </Flex>

--- a/packages/frontend/pages/users/[walletId].tsx
+++ b/packages/frontend/pages/users/[walletId].tsx
@@ -4,7 +4,7 @@ import {
   Grid,
   GridItem,
   Spinner,
-  VStack,
+  VStack
 } from '@chakra-ui/react'
 import { CreatorCard } from '@components/creator/CreatorCard'
 import Feed from '@components/Feed'

--- a/packages/frontend/pages/users/[walletId].tsx
+++ b/packages/frontend/pages/users/[walletId].tsx
@@ -1,4 +1,11 @@
-import { Center, Container, Flex, Grid, GridItem, Spinner, VStack } from '@chakra-ui/react'
+import {
+  Center,
+  Container,
+  Grid,
+  GridItem,
+  Spinner,
+  VStack,
+} from '@chakra-ui/react'
 import { CreatorCard } from '@components/creator/CreatorCard'
 import Feed from '@components/Feed'
 import Layout from '@components/layout/Layout'
@@ -21,14 +28,18 @@ export default function UsersPage() {
     accountData?.address &&
     accountData?.address.toLowerCase() === walletId.toLowerCase()
   const [creator, setCreator] = useState<Creator | null>(null)
-  const { supporterAmountStaked, refetch: refetchSupporterAmountStaked } = useSupporterAmountStaked({ supporter: accountData?.address, beneficiary: creator?.address })
+  const { supporterAmountStaked, refetch: refetchSupporterAmountStaked } =
+    useSupporterAmountStaked({
+      supporter: accountData?.address,
+      beneficiary: creator?.address,
+    })
   const [contentIsLocked, setContentIsLocked] = useState(true)
-  
+
   // Content Lock
   useEffect(() => {
     setContentIsLocked(!isOwner && (supporterAmountStaked || 0) <= 0)
   }, [supporterAmountStaked])
-  
+
   // Fetch Creator
   const fetchCreator = async (): Promise<Creator> => {
     const res = await fetch('/api/creators/getCreator', {
@@ -61,33 +72,46 @@ export default function UsersPage() {
     return <>Not a valid address</>
   }
 
-  if (!creator) return <>
-    <Center>
-      <Spinner size='xl' my='100' />
-    </Center>
-  </>
+  if (!creator)
+    return (
+      <>
+        <Center>
+          <Spinner size="xl" my="100" />
+        </Center>
+      </>
+    )
 
-  return (<>
+  return (
     <Layout>
       <Container maxW="5xl">
-        <Grid templateColumns="350px 1fr" gap={10} py={10}>
-          <Flex direction="column" gap={10} width="full">
-            <VStack
-              position="sticky"
-              spacing={8}
-              width="full"
-              align="stretch"
-            >
-              <CreatorCard creator={creator} isOwner={!!isOwner} updateContentIsLocked={refetchSupporterAmountStaked} />
-              <SponsorsCard sponsors={creator?.supporters} />
-            </VStack>
-          </Flex>
+        <Grid
+          templateColumns={{ base: '1fr', md: 'auto 1fr' }}
+          placeItems="start stretch"
+          gap={10}
+          py={10}
+        >
+          <VStack
+            position={{ base: 'static', md: 'sticky' }}
+            top="8"
+            spacing={8}
+            width="full"
+            align="stretch"
+          >
+            <CreatorCard
+              creator={creator}
+              isOwner={!!isOwner}
+              updateContentIsLocked={refetchSupporterAmountStaked}
+            />
+            <SponsorsCard sponsors={creator?.supporters} />
+          </VStack>
           <GridItem>
-            {isOwner && <NewPostForm creator={creator} setCreator={setCreator} />}
+            {isOwner && (
+              <NewPostForm creator={creator} setCreator={setCreator} />
+            )}
             <Feed feed={creator?.posts || []} isLocked={contentIsLocked} />
           </GridItem>
         </Grid>
       </Container>
     </Layout>
-  </>)
+  )
 }


### PR DESCRIPTION
Summary of changes:

- Improved `BlockiesAvatar` by replacing useState and useEffect with useMemo. I also removed Box and extended ImageProps to make it more reusable/maintainable.
- Removed the flex order and justifyContent keys in `ConnectWallet` to fix the swapping of elements in the navbar.
- Improved `ConnectWalletButton` to accept all possible button props and forward them to the underlying button. I also set a default of 200px for its width (was 220px) because that was causing some responsiveness issues on narrow screens.
- Made the avatar size responsive in `CreatorCardDetails`
- Made some changes in `CreatorCardNumbers` to allow wrapping and keep things looking somewhat okay when that happens.
- Changed `CreatorList` from the homepage from a flex-based to a grid-based layout that adapts better to different widths. The "iPad range" is not ideal, with a lot of empty space, but that's what we get with the Chakra's default breakpoints without getting too much into the weeds.
- Changed `Layout` so that the footer remains at the bottom when a view's content doesn't fill a whole viewport height.
- Changed the layout of logos on the homepage for better responsiveness.
- Changed the layout of `[walletId]` for better responsiveness.

The diffs include a lot of formatting changes automatically made by Prettier. I think we should probably make sure our Prettier configs are working in the same direction. From the before and afters I think mine is working fine, but let me know if you think otherwise. We would probably benefit from making a big reformatting commit once that is established, so that actual code changes are easier to glean in future PRs.

The layout is still not worthy of a webby award, specially at some viewport widths, but it's an improvement from what we had and the most painful issues (overflows on narrow screens) should be fixed.

Let me know if you find any remaining glaring issues and feel free to raise any points with the implementation.