### PR TITLE
Refine Deploy Workflow Aliases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           ALIAS_DOMAINS: |
-            ygyg.vercel.app
+            ygyg-dev.vercel.app
           PRODUCTION: false
           GITHUB_DEPLOYMENT_ENV: Staging
           FORCE: true
@@ -50,8 +50,6 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          ALIAS_DOMAINS: |
-            yieldgate.xyz
           PRODUCTION: true
           GITHUB_DEPLOYMENT_ENV: Production
           FORCE: true


### PR DESCRIPTION
* Vercel somehow erros and says that we don't have access to `yieldgate.xyz` (which is not true). Maybe a bug on their side. But as I guess they assign that domain to production deploys anyways we can probably just remove it for now.
* Vercel seems to automatically assign `ygyg.vercel.app` to production. Try using `ygyg-dev.vercel.app` instead.
* I also opened https://github.com/BetaHuhn/deploy-to-vercel-action/issues/192. But I guess we can ignore this warning for now.