### PR TITLE
Github CI and linting/formatting improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Lint+Build
+    name: Lint+Test
     timeout-minutes: 15
     runs-on: ubuntu-latest
 
@@ -29,4 +29,4 @@ jobs:
         run: pnpm install
 
       - name: Lint
-        run: pnpm lint
+        run: pnpm lint:all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Lint+Test
+    name: Lint
     timeout-minutes: 15
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  build:
+    name: Lint+Build
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 7
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Lint
+        run: pnpm lint

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ name: Deploy to Vercel CI
 on:
   workflow_dispatch:
   push:
-    branches: [main,develop]
+    branches: [main, develop]
 
 jobs:
   deploy:

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,5 @@
 {
   "*.{js,jsx,ts,tsx}": ["eslint --fix", "prettier --write"],
-  "*.{md,html,css,json}": "prettier --write"
+  "*.{md,html,css,json,yml}": "prettier --write",
+  "*.sol": "solhint --fix"
 }

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,4 @@
 {
   "*.{js,jsx,ts,tsx}": ["eslint --fix", "prettier --write"],
-  "*.{md,html,css,json,yml}": "prettier --write",
-  "*.sol": "solhint --fix"
+  "*.{md,html,css,json,yml}": "prettier --write"
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+pnpm-lock.yaml
+pnpm-workspace.yaml
+packages

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "build": "turbo run build",
     "lint:all": "turbo run lint",
     "lint": "prettier . --check",
-    "format:all": "turbo run format",
-    "format": "prettier . --write",
+    "lint:fix:all": "turbo run lint:fix",
+    "lint:fix": "prettier . --write",
     "frontend:dev": "pnpm --filter frontend dev",
     "frontend:start": "pnpm --filter frontend start",
     "prepare": "husky install"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
   "scripts": {
     "dev": "turbo run dev",
     "build": "turbo run build",
-    "format": "turbo run format",
+    "lint:all": "turbo run lint",
+    "lint": "prettier . --check",
+    "format:all": "turbo run format",
+    "format": "prettier . --write",
     "frontend:dev": "pnpm --filter frontend dev",
     "frontend:start": "pnpm --filter frontend start",
     "prepare": "husky install"

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "lint": "prettier . --check",
     "lint:fix:all": "turbo run lint:fix",
     "lint:fix": "prettier . --write",
-    "frontend:dev": "pnpm --filter frontend dev",
-    "frontend:start": "pnpm --filter frontend start",
+    "dev:frontend": "pnpm --filter frontend dev",
+    "start:frontend": "pnpm --filter frontend start",
     "prepare": "husky install"
   },
   "devDependencies": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -8,7 +8,7 @@
     "start": "NODE_ENV=production next start",
     "type-check": "tsc --pretty --noEmit",
     "lint": "prettier . --check && pnpm eslint",
-    "format": "prettier . --write && pnpm eslint --fix",
+    "lint:fix": "prettier . --write && pnpm eslint --fix",
     "eslint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "test": "jest --passWithNoTests"
   },

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -7,8 +7,9 @@
     "build": "NODE_ENV=production next build",
     "start": "NODE_ENV=production next start",
     "type-check": "tsc --pretty --noEmit",
-    "lint": "eslint --ext .js,.jsx,.ts,.tsx --fix .",
-    "format": "prettier --write .",
+    "lint": "prettier . --check && pnpm eslint",
+    "format": "prettier . --write && pnpm eslint --fix",
+    "eslint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "test": "jest --passWithNoTests"
   },
   "dependencies": {

--- a/packages/hardhat/.prettierignore
+++ b/packages/hardhat/.prettierignore
@@ -1,6 +1,4 @@
-node_modules
-cache 
+cache
 contracts
 yarn.lock
 package-lock.json
-public

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -11,7 +11,7 @@
     "deploy": "pnpm hardhat run scripts/deploy.ts",
     "deploy:mumbai": "pnpm hardhat run scripts/deploy.ts --network mumbai",
     "lint": "prettier . --check && pnpm eslint && pnpm solhint",
-    "format": "prettier . --write && pnpm eslint --fix && pnpm solhint --fix",
+    "lint:fix": "prettier . --write && pnpm eslint --fix && pnpm solhint --fix",
     "eslint": "eslint . --ext .js,.ts",
     "solhint": "solhint 'contracts/**/*.sol'"
   },

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -10,10 +10,10 @@
     "typechain": "pnpm hardhat typechain",
     "deploy": "pnpm hardhat run scripts/deploy.ts",
     "deploy:mumbai": "pnpm hardhat run scripts/deploy.ts --network mumbai",
-    "lint": "pnpm eslint && pnpm solhint",
-    "eslint": "eslint --ext .js,.jsx,.ts,.tsx --fix .",
-    "solhint": "solhint 'contracts/**/*.sol'",
-    "format": "prettier --write ."
+    "lint": "prettier . --check && pnpm eslint && pnpm solhint",
+    "format": "prettier . --write && pnpm eslint --fix && pnpm solhint --fix",
+    "eslint": "eslint . --ext .js,.ts",
+    "solhint": "solhint 'contracts/**/*.sol'"
   },
   "devDependencies": {
     "@ethersproject/abi": "^5.6.4",

--- a/turbo.json
+++ b/turbo.json
@@ -14,9 +14,14 @@
       "dependsOn": ["@yieldgate/hardhat#build"],
       "outputs": [".next/**", "artifacts/**"]
     },
-    "format": {
-      "dependsOn": ["^format"]
-    }
+    "lint": {
+      "outputs": []
+    },
+    "//#lint": {
+      "outputs": []
+    },
+    "format": {},
+    "//#format": {}
   },
   "globalDependencies": [
     ".env",


### PR DESCRIPTION
- chore: Add .prettierignore to root
- chore/hardhat: Remove superfluous .prettierignore entries
- chore: lint-staged: Add .yml to prettier, .sol to solhint hook
- frontend: Improve lint and format scripts
- hardhat: Improve lint and format scripts
- chore: Add prettier lint and format scripts to monorepo root
- chore: turbo: Add lint pipeline, add root lint&format to pipelines
- ci: Fix formatting in deploy.yml GH action
- ci: Add CI Github action
